### PR TITLE
Made port customizable

### DIFF
--- a/jd.conf.json-dist
+++ b/jd.conf.json-dist
@@ -1,5 +1,6 @@
 {
 	"jenkinsURL": "the.jenkins.url",
+	"jenkinsPORT": 443,
 	"jenkinsAuth": {
 		"type": "basic",
 		"fileName": "/path/to/auth.txt"

--- a/server/jenkins-helper.js
+++ b/server/jenkins-helper.js
@@ -30,6 +30,10 @@ jh.setURL = function(url) {
 	this.url = url;
 	log('Using jenkins api from '+ url);
 }
+jh.setPORT = function(port) {
+	this.port = port;
+	log('Using jenkins api on port ' + port);
+}
 jh.setDebug = function(v) { this.debug = v; }
 jh.setUseFixtures = function(v) {
 	if (v) log('Not making any http call to jenkins: using fixtures');
@@ -41,6 +45,7 @@ jh.get = function(path) {
 		results = '',
 		options = {
 			host: this.url,
+			port: this.port,
 			secureProtocol: 'SSLv3_method',
 			path: (path).replace(/\s/g,"%20"),
 			timeout: FORCE_REFRESH_MS

--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,13 @@ if (typeof(jenkinsURL) === 'undefined') {
 	jenkins.setURL(jenkinsURL);
 }
 
+var jenkinsPORT = conf.get('jenkinsPORT');
+if (typeof(jenkinsPORT) === 'undefined') {
+	jenkins.log('no jenkinsPORT found in the conf file (' + conf.get('conf') + ') use default 443');
+    jenkinsPORT = 443
+}
+jenkins.setPORT(jenkinsPORT);
+
 
 var authenticator,
 	noop = function() {}, 


### PR DESCRIPTION
In our environment we don't use default ssl port, but a custom one. After this PR user will be able to configure it via the config file.